### PR TITLE
Update to Dioxus 0.5.1 and code cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,4 @@ doctest = false
 [dependencies]
 dioxus = { version = "0.5.1" }
 web-sys = { version = "0.3.59", features = ["Document", "Window", "Element", "HtmlHeadElement", "HtmlCollection", "NamedNodeMap", "NodeList"] }
-lazy_static = "1.4.0"
 rustc-hash = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/saicu/dioxus-helmet"
 doctest = false
 
 [dependencies]
-dioxus = { git = "https://github.com/DioxusLabs/dioxus" }
+dioxus = { version = "0.5.1" }
 web-sys = { version = "0.3.59", features = ["Document", "Window", "Element", "HtmlHeadElement", "HtmlCollection", "NamedNodeMap", "NodeList"] }
 lazy_static = "1.4.0"
 rustc-hash = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "dioxus-helmet"
-version = "0.2.4"
+version = "0.5.1"
 authors = ["Saicu"]
 edition = "2021"
 description = "Small Dioxus component which allows you to place elements in the head of your document"
 license = "MIT"
-repository = "https://github.com/saicu/dioxus-helmet"
+repository = "https://github.com/dioxus-community/dioxus-helmet"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -14,4 +14,4 @@ doctest = false
 [dependencies]
 dioxus = { version = "0.5.1" }
 web-sys = { version = "0.3.69", features = ["Document", "Window", "Element", "HtmlHeadElement"] }
-rustc-hash = "1.1.0"
+rustc-hash = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ dioxus = { version = "0.5.1" }
 web-sys = { version = "0.3.59", features = ["Document", "Window", "Element", "HtmlHeadElement", "HtmlCollection", "NamedNodeMap", "NodeList"] }
 lazy_static = "1.4.0"
 rustc-hash = "1.1.0"
-js-sys = "0.3.59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ doctest = false
 
 [dependencies]
 dioxus = { version = "0.5.1" }
-web-sys = { version = "0.3.59", features = ["Document", "Window", "Element", "HtmlHeadElement", "HtmlCollection", "NamedNodeMap", "NodeList"] }
+web-sys = { version = "0.3.69", features = ["Document", "Window", "Element", "HtmlHeadElement"] }
 rustc-hash = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ use dioxus_helmet::Helmet;
 Then use it as a component like this:
 
 ```rust
-#[inline_props]
-fn HeadElements(cx: Scope, path: String) -> Element {
-    cx.render(rsx! {
+#[component]
+fn HeadElements(path: String) -> Element {
+    rsx! {
         Helmet {
             link { rel: "icon", href: "{path}"}
             title { "Helmet" }
@@ -44,15 +44,15 @@ fn HeadElements(cx: Scope, path: String) -> Element {
                 "#]
             }
         }
-    })
+    }
 }
 ```
 
-Reach your dynamic values down as owned properties (eg `String` and **not** `&'a str`).
-
-Also make sure that there are **no states** in your component where you use Helmet.
-
 Any children passed to the helmet component will then be placed in the `<head></head>` of your document.
+
+**IMPORTANT**: The nodes inside the `Helmet` component are not reactive, so they won't be updated
+when the value of them changes. So it's better to use static values inside the `Helmet`
+component instead of signals.
 
 They will be visible while the component is rendered. Duplicates **won't** get appended multiple times.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,14 +47,11 @@
 
 use dioxus::prelude::*;
 use dioxus_core::AttributeValue;
-use lazy_static::lazy_static;
 use rustc_hash::FxHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Mutex;
 
-lazy_static! {
-    static ref INIT_CACHE: Mutex<Vec<u64>> = Mutex::new(Vec::new());
-}
+static INIT_CACHE: Mutex<Vec<u64>> = Mutex::new(Vec::new());
 
 #[allow(non_snake_case)]
 #[component]


### PR DESCRIPTION
I updated the code for Dioxus 0.5.1 and cleaned the code.
I rewrote nested if let as let else, updated the dependencies.

There is a functional change: the `data-helment-id` was removed, Elements are tracked using the mounted_element field of ElementMap, this removes the need to query the dom to search the Elements to remove.

Closes #3
